### PR TITLE
Implement simple calendar

### DIFF
--- a/src/pages/en/events.html
+++ b/src/pages/en/events.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Upcoming Events | KJ's Camping</title>
+  <link rel="stylesheet" href="../styles/main.css">
+  <link rel="stylesheet" href="../styles/events.css">
+</head>
+<body>
+  <!-- Dynamic header -->
+  <div id="header-placeholder"></div>
+  <main id="page-content" class="fade-container">
+    <h1 data-key="upcomingEvents">Upcoming Events</h1>
+    <div id="calendar"></div>
+  </main>
+  <!-- Dynamic footer -->
+  <div id="footer-placeholder"></div>
+  <script type="module" src="../../scripts/events.js"></script>
+  <script>
+    // Load header and footer then initialise header.js
+    Promise.all([
+      fetch('../components/header.html').then(r => r.text()).then(h => {
+        document.querySelector('#header-placeholder').innerHTML = h;
+      }),
+      fetch('../components/footer.html').then(r => r.text()).then(h => {
+        document.querySelector('#footer-placeholder').innerHTML = h;
+      })
+    ]).then(() => {
+      const year = document.getElementById('year');
+      if (year) year.textContent = new Date().getFullYear();
+      const headerScript = document.createElement('script');
+      const base = window.location.pathname.split('/pages')[0];
+      headerScript.type = 'module';
+      headerScript.src = `${base}/scripts/header.js`;
+      document.body.appendChild(headerScript);
+    });
+  </script>
+  <script src="../../scripts/main.js"></script>
+</body>
+</html>

--- a/src/pages/it/events.html
+++ b/src/pages/it/events.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Prossimi Eventi | KJ's Camping</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.css">
+  <link rel="stylesheet" href="../styles/main.css">
   <link rel="stylesheet" href="../styles/events.css">
 </head>
 <body>
@@ -16,7 +16,6 @@
   </main>
   <!-- Footer dinamico -->
   <div id="footer-placeholder"></div>
-  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.js"></script>
   <script type="module" src="../../scripts/events.js"></script>
   <script>
     // Carica header e footer quindi avvia header.js per la traduzione

--- a/src/pages/nl/events.html
+++ b/src/pages/nl/events.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Komende Evenementen | KJ's Camping</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.css">
+  <link rel="stylesheet" href="../styles/main.css">
   <link rel="stylesheet" href="../styles/events.css">
 </head>
 <body>
@@ -16,7 +16,6 @@
   </main>
   <!-- Dynamische footer -->
   <div id="footer-placeholder"></div>
-  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.js"></script>
   <script type="module" src="../../scripts/events.js"></script>
   <script>
     // Eerst header en footer laden, dan header.js activeren

--- a/src/pages/styles/events.css
+++ b/src/pages/styles/events.css
@@ -1,4 +1,4 @@
-/* ========= React Calendar overrides ========= */
+/* ========= Simple Calendar Styles ========= */
 .calendar-container{
   width: min(90vw, 1100px);
   margin: 3rem auto;
@@ -30,7 +30,7 @@
   width: 100%;
   table-layout: fixed;
   border-collapse: collapse;
-  background: var(--background, #fff);                 /* inherit site background */
+  background: #fff;
 }
 
 #page-content .calendar-table th,
@@ -68,3 +68,14 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.past-day {
+  background: #eee;
+  color: #999;
+}
+
+.today {
+  background: var(--burnt);
+  color: var(--light);
+}
+

--- a/src/scripts/events.js
+++ b/src/scripts/events.js
@@ -1,0 +1,68 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('calendar');
+  if (!container) return;
+
+  let current = new Date();
+  current.setDate(1);
+  const today = new Date();
+
+  function render() {
+    const year = current.getFullYear();
+    const month = current.getMonth();
+    const firstDay = new Date(year, month, 1);
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const startIndex = (firstDay.getDay() + 6) % 7; // monday start
+
+    let html = '<div class="calendar-header">';
+    html += '<button class="nav-button" id="prev-month">\u2039</button>';
+    html += `<div class="month-year">${firstDay.toLocaleDateString(undefined, { month: 'long', year: 'numeric' })}</div>`;
+    html += '<button class="nav-button" id="next-month">\u203A</button>';
+    html += '</div>';
+
+    html += '<table class="calendar-table"><thead><tr>';
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(2021, 0, 4 + i); // Monday based labels
+      html += `<th>${d.toLocaleDateString(undefined, { weekday: 'short' })}</th>`;
+    }
+    html += '</tr></thead><tbody>';
+
+    let day = 1;
+    const rows = Math.ceil((startIndex + daysInMonth) / 7);
+    for (let r = 0; r < rows; r++) {
+      html += '<tr>';
+      for (let c = 0; c < 7; c++) {
+        const cell = r * 7 + c;
+        if (cell < startIndex || day > daysInMonth) {
+          html += '<td></td>';
+        } else {
+          const cellDate = new Date(year, month, day);
+          let classes = 'calendar-cell';
+          if (cellDate < new Date(today.getFullYear(), today.getMonth(), today.getDate())) {
+            classes += ' past-day';
+          }
+          if (cellDate.getFullYear() === today.getFullYear() &&
+              cellDate.getMonth() === today.getMonth() &&
+              cellDate.getDate() === today.getDate()) {
+            classes += ' today';
+          }
+          html += `<td class="${classes}"><span class="date-number">${day}</span></td>`;
+          day++;
+        }
+      }
+      html += '</tr>';
+    }
+    html += '</tbody></table>';
+    container.innerHTML = html;
+
+    document.getElementById('prev-month').addEventListener('click', () => {
+      current.setMonth(current.getMonth() - 1);
+      render();
+    });
+    document.getElementById('next-month').addEventListener('click', () => {
+      current.setMonth(current.getMonth() + 1);
+      render();
+    });
+  }
+
+  render();
+});


### PR DESCRIPTION
## Summary
- build standalone calendar script and style
- use main.css on events pages for consistent look
- drop FullCalendar CDN references
- add missing English events page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e716909c4832ebcdd0fd770542586