### PR TITLE
Add dev scrum board

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ These instructions apply to the entire project repository and describe how Codex
 - Shared components are in `src/pages/components` and assets in `src/assets`.
 - Test scripts reside in `test/`.
 - Do **not** commit files in `node_modules/` or `dist/`.
+- Ignore the `dev/` directory; it contains experimental utilities unrelated to
+  the production site.
 
 ## Testing
 - Run `npm install` whenever `package.json` or `package-lock.json` changes.

--- a/dev/scrum.html
+++ b/dev/scrum.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Dev Scrum Board</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+    }
+    .board {
+      display: flex;
+      gap: 20px;
+    }
+    .column {
+      flex: 1;
+      border: 1px solid #ccc;
+      padding: 10px;
+      min-height: 200px;
+    }
+    .column h2 {
+      text-align: center;
+    }
+    ul {
+      list-style: none;
+      padding: 0;
+    }
+    li {
+      margin: 5px 0;
+      padding: 5px;
+      background: #f0f0f0;
+    }
+    button {
+      margin-left: 5px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Scrum Board</h1>
+  <div class="board">
+    <div class="column" id="todoColumn">
+      <h2>To Do</h2>
+      <input id="newTask" placeholder="New task">
+      <button onclick="addTask()">Add</button>
+      <ul id="todoList"></ul>
+    </div>
+    <div class="column" id="progressColumn">
+      <h2>In Progress</h2>
+      <ul id="progressList"></ul>
+    </div>
+    <div class="column" id="doneColumn">
+      <h2>Done</h2>
+      <ul id="doneList"></ul>
+    </div>
+  </div>
+
+  <script>
+    const fs = require('fs');
+    const path = require('path');
+    const dataFile = path.join(__dirname, 'scrumData.json');
+
+    function loadData() {
+      try {
+        return JSON.parse(fs.readFileSync(dataFile, 'utf8'));
+      } catch (e) {
+        return { todo: [], progress: [], done: [] };
+      }
+    }
+
+    function saveData(data) {
+      fs.writeFileSync(dataFile, JSON.stringify(data, null, 2));
+    }
+
+    let board = loadData();
+
+    function render() {
+      document.getElementById('todoList').innerHTML = '';
+      document.getElementById('progressList').innerHTML = '';
+      document.getElementById('doneList').innerHTML = '';
+
+      board.todo.forEach((task, idx) => {
+        const li = document.createElement('li');
+        li.textContent = task;
+        li.appendChild(createButton('Start', () => moveTask('todo', 'progress', idx)));
+        document.getElementById('todoList').appendChild(li);
+      });
+
+      board.progress.forEach((task, idx) => {
+        const li = document.createElement('li');
+        li.textContent = task;
+        li.appendChild(createButton('Done', () => moveTask('progress', 'done', idx)));
+        document.getElementById('progressList').appendChild(li);
+      });
+
+      board.done.forEach(task => {
+        const li = document.createElement('li');
+        li.textContent = task;
+        document.getElementById('doneList').appendChild(li);
+      });
+    }
+
+    function createButton(label, onClick) {
+      const btn = document.createElement('button');
+      btn.textContent = label;
+      btn.addEventListener('click', onClick);
+      return btn;
+    }
+
+    function moveTask(from, to, index) {
+      board[to].push(board[from][index]);
+      board[from].splice(index, 1);
+      saveData(board);
+      render();
+    }
+
+    function addTask() {
+      const input = document.getElementById('newTask');
+      const task = input.value.trim();
+      if (!task) return;
+      board.todo.push(task);
+      input.value = '';
+      saveData(board);
+      render();
+    }
+
+    render();
+  </script>
+</body>
+</html>

--- a/dev/scrumData.json
+++ b/dev/scrumData.json
@@ -1,0 +1,5 @@
+{
+  "todo": [],
+  "progress": [],
+  "done": []
+}


### PR DESCRIPTION
## Summary
- create `dev/` folder with a simple scrum board HTML that persists data to `scrumData.json`
- store initial JSON data in the same folder
- note in `AGENTS.md` that `dev/` is an experimental directory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f73d1cbbc832e9b04d5cc36a09367