### PR TITLE
Add redirecting index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,14 @@ Launch the experimental drag-and-drop scrum board:
 npm run scrum
 ```
 The board supports drag-and-drop task management and a checkbox to mark tasks as minor.
+
+### Local preview of GitHub Pages
+
+To verify the redirect logic before pushing to `main`, build the site and run a local preview server:
+
+```bash
+npm run build
+npm run preview
+```
+
+Open the printed URL and navigate to `/pages/` to check that you're redirected to the language stored in the browser (or English when none is saved).

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>KJ's Campfire</title>
+  <script>
+    const stored = localStorage.getItem('site-lang');
+    const browser = (navigator.language || 'en').slice(0, 2).toLowerCase();
+    const lang = ['en', 'it', 'nl'].includes(stored)
+                ? stored
+                : (['en', 'it', 'nl'].includes(browser) ? browser : 'en');
+    let base = window.location.pathname.split('/pages')[0];
+    base = base.replace(/\/$/, '').replace(/\/index\.html$/, '');
+    window.location.replace(`${base}/pages/${lang}/`);
+  </script>
+</head>
+<body>
+  <noscript>
+    <a href="en/">English</a> |
+    <a href="it/">Italiano</a> |
+    <a href="nl/">Nederlands</a>
+  </noscript>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redirect from `src/pages/index.html` to the preferred language
- document how to preview the site locally before deploying

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687f8f9be92c832ebb9285d2fab6b29f