### PR TITLE
Add 404 redirect fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # If you build (e.g. Vite/React) uncomment:
-      # - run: npm ci && npm run build
+      - run: npm ci
+      - run: npm run build
       - uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./src
+          publish_dir: ./dist
+          publish_branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -38,3 +38,16 @@ Launch the experimental drag-and-drop scrum board:
 npm run scrum
 ```
 The board supports drag-and-drop task management and a checkbox to mark tasks as minor.
+
+## Deployment
+
+Build the site and publish it to GitHub Pages:
+
+```bash
+npm run deploy
+```
+The workflow in `.github/workflows/deploy.yml` runs this on every push to `main`.
+It builds using Vite with `base` set to `/campeggio/` and publishes the `dist`
+folder to the `gh-pages` branch so an `index.html` exists at the branch root.
+The build also includes a `404.html` page so GitHub Pages displays a friendly
+message when a URL doesn't match any file.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "scrum": "node dev/scrum-server.js",
-    "test": "node test/checkPaths.js"
+    "test": "node test/checkPaths.js",
+    "deploy": "npm run build && gh-pages -d dist"
   },
   "author": "Joost van Tiggelen",
   "license": "ISC",

--- a/src/404.html
+++ b/src/404.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Not Found</title>
+  <link rel="stylesheet" href="./pages/styles/main.css">
+</head>
+<body>
+  <main class="container" style="text-align:center; padding:4rem 1rem;">
+    <h1>404 - Page Not Found</h1>
+    <p>Oops! The page you're looking for doesn't exist.</p>
+    <p><a href="index.html">Return to the home page</a></p>
+  </main>
+  <script>
+    const path = window.location.pathname;
+    if (/\/pages\/(en|it|nl)$/.test(path)) {
+      window.location.replace(`${path}/`);
+    }
+  </script>
+</body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import { resolve } from 'path'
 
 export default defineConfig({
   root: 'src',
+  base: '/campeggio/',
   publicDir: resolve(__dirname, 'src/assets'),
   build: {
     outDir: resolve(__dirname, 'dist'),
@@ -22,6 +23,7 @@ export default defineConfig({
         nlAbout: resolve(__dirname, 'src/pages/nl/about.html'),
         nlContact: resolve(__dirname, 'src/pages/nl/contact.html'),
         nlEvents: resolve(__dirname, 'src/pages/nl/events.html'),
+        notFound: resolve(__dirname, 'src/404.html'),
       }
     }
   }


### PR DESCRIPTION
## Summary
- add redirect logic in the custom 404 page to handle URLs missing a trailing slash
- keep gh-pages deploy workflow that builds dist and publishes it

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f963d7b68832e9f9f58ec20090207